### PR TITLE
Reload the default settings on homepage load

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,11 +6,7 @@ import Footer from './components/Footer';
 import HeaderNav from './components/Header';
 import Navbar from 'react-bootstrap/Navbar';
 import { getSessionCookie, removeSessionCookie } from './components/Session';
-import {
-  UseGlobalSession,
-  getDefaults,
-  UseGlobalSettings
-} from './components/Global';
+import { UseGlobalSession, UseGlobalSettings } from './components/Global';
 import Logo from './data/Logo';
 
 export default function App() {
@@ -45,7 +41,6 @@ export default function App() {
         })
         .then(() => {
           globalActions.setSession(session);
-          getDefaults(session, globalSettingsActions);
         })
         .catch((e: Error) => {
           if (e.name === 'SyntaxError') {

--- a/ui/src/components/Global.ts
+++ b/ui/src/components/Global.ts
@@ -1,4 +1,4 @@
-import { Session, defaultSession, setSessionCookie } from './Session';
+import { Session, defaultSession } from './Session';
 import globalHook, { Store } from 'use-global-hook';
 import React from 'react';
 import { Settings } from './settings/Settings';
@@ -23,7 +23,7 @@ export const UseGlobalSession = globalHook<Session, GlobalSessionActions>(
 
 //
 
-type GlobalSettingsActions = {
+export type GlobalSettingsActions = {
   setSettings: (value: Settings) => void;
 };
 
@@ -47,7 +47,7 @@ export type Sim = {
   Quantity: number;
 };
 
-type GlobalSimActions = {
+export type GlobalSimActions = {
   setSim: (value: Sim) => void;
 };
 
@@ -67,7 +67,7 @@ export type Grafana = {
   Active: boolean;
 };
 
-type GlobalGrafanaActions = {
+export type GlobalGrafanaActions = {
   setGrafana: (value: Grafana) => void;
 };
 
@@ -80,25 +80,3 @@ export const UseGlobalGrafana = globalHook<Grafana, GlobalGrafanaActions>(
   { Active: true },
   { setGrafana: setGrafana }
 );
-
-//
-
-export function getDefaults(
-  session: Session,
-  globalSettingsActions: GlobalSettingsActions
-): void {
-  const url = session.endpoint + '/example';
-  console.log('Get settings from ' + url);
-
-  fetch(url, {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    }
-  })
-    .then(response => response.json())
-    .then(data => globalSettingsActions.setSettings(data))
-    .catch(() => {
-      setSessionCookie(defaultSession);
-    });
-}

--- a/ui/src/components/deployment/Form.tsx
+++ b/ui/src/components/deployment/Form.tsx
@@ -1,30 +1,47 @@
-import React, { useState, Component } from 'react';
-import { Button, Container, Row, Col } from 'react-bootstrap';
+import React, { useState, useEffect } from 'react';
+import { Container, Row, Col } from 'react-bootstrap';
 import { Route, Link, match } from 'react-router-dom';
 import OptionCard from '../OptionCard';
 import BigButton from '../BigButton';
+import setDefaults from '../settings/SetDefaults';
+import {
+  UseGlobalSession,
+  UseGlobalSettings,
+  UseGlobalGrafana,
+  UseGlobalSim
+} from '../Global';
 
-class RoutedLink extends Component<{
-  to: string;
-  disabled: boolean;
-}> {
-  render() {
-    const data = {
-      label: '',
-      path: this.props.to,
-      exact: false,
-      children: ({ match }: { match: match }) => (
-        <Link to={this.props.to} className="text-decoration-none">
-          <BigButton disabled={this.props.disabled}>Get Started</BigButton>
-        </Link>
-      )
-    };
-    return <Route {...data} />;
-  }
+function RoutedLink(props: { to: string; disabled: boolean }) {
+  const data = {
+    label: '',
+    path: props.to,
+    exact: false,
+    children: ({ match }: { match: match }) => (
+      <Link to={props.to} className="text-decoration-none">
+        <BigButton disabled={props.disabled}>Get Started</BigButton>
+      </Link>
+    )
+  };
+
+  return <Route {...data} />;
 }
 
 export default function DeployForm() {
   const [direct, setDirect] = useState('');
+
+  const globalState = UseGlobalSession()[0];
+  const globalSettingsActions = UseGlobalSettings()[1];
+  const globalGrafanaActions = UseGlobalGrafana()[1];
+  const globalSimActions = UseGlobalSim()[1];
+
+  useEffect(() => {
+    setDefaults(
+      globalState,
+      globalSettingsActions,
+      globalGrafanaActions,
+      globalSimActions
+    );
+  }, []);
 
   return (
     <Container>

--- a/ui/src/components/settings/SetDefaults.ts
+++ b/ui/src/components/settings/SetDefaults.ts
@@ -1,0 +1,31 @@
+import { setSessionCookie, defaultSession, Session } from '../Session';
+import {
+  GlobalSettingsActions,
+  GlobalGrafanaActions,
+  GlobalSimActions
+} from '../Global';
+
+export default function setDefaults(
+    globalState: Session,
+    globalSettingsActions: GlobalSettingsActions,
+    globalGrafanaActions: GlobalGrafanaActions,
+    globalSimActions: GlobalSimActions
+) {
+  const url = globalState.endpoint + '/example';
+  console.log('Get settings from ' + url);
+
+  fetch(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+    .then(response => response.json())
+    .then(data => globalSettingsActions.setSettings(data))
+    .then(x => globalGrafanaActions.setGrafana({ Active: true }))
+    .then(x => globalSimActions.setSim({ Active: false, Quantity: 0 }))
+    .catch((e: Error) => {
+      console.log(e.message);
+      setSessionCookie(defaultSession);
+    });
+}

--- a/ui/src/views/Form.tsx
+++ b/ui/src/views/Form.tsx
@@ -23,8 +23,7 @@ export default function FormView(props: React.PropsWithChildren<State>) {
     if (form.checkValidity() === false) {
       event.preventDefault();
       event.stopPropagation();
-    }
-    else {
+    } else {
       globalSettingsActions.setSettings(state);
       redirect(true);
     }
@@ -49,16 +48,13 @@ export default function FormView(props: React.PropsWithChildren<State>) {
 
       <Row className="justify-content-md-center">
         <Form noValidate validated={validated} onSubmit={handleSubmit}>
-          {toDeploy && <Redirect to={"/deploy?ref=" + page} />}
+          {toDeploy && <Redirect to={'/deploy?ref=' + page} push />}
 
           {children}
 
           <Row className="mt-2">
             <Col>
-              <Button
-                variant="success"
-                type="submit"
-              >
+              <Button variant="success" type="submit">
                 Deploy
               </Button>
             </Col>

--- a/ui/src/views/Login.tsx
+++ b/ui/src/views/Login.tsx
@@ -2,15 +2,10 @@ import React, { useState, useEffect } from 'react';
 import { Button, Form, Alert } from 'react-bootstrap';
 import { setSessionCookie, Session } from '../components/Session';
 import { Redirect } from 'react-router';
-import {
-  UseGlobalSession,
-  UseGlobalSettings,
-  getDefaults
-} from '../components/Global';
+import { UseGlobalSession } from '../components/Global';
 
 export default function Login() {
   const [globalState, globalActions] = UseGlobalSession();
-  const [globalSettings, globalSettingsActions] = UseGlobalSettings();
   const [key, setKey] = useState('');
   const [toHome, redirect] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
@@ -55,8 +50,6 @@ export default function Login() {
 
         setSessionCookie(session);
         globalActions.setSession(session);
-
-        getDefaults(session, globalSettingsActions);
 
         redirect(true);
       })


### PR DESCRIPTION
Closes #44 

This accomplishes a number of things.

Firstly, it prevents setting changes made in one form from influencing the global settings inside another form.

It also prevents staleness (load ui -> upgrade/relanch -> submit without refreshing the page) and will kill the session if a user is no longer running the server.

It also lets users back out of the confirm deployment screen, since settings are not overwritten until the entire flow is relaunched.