### PR TITLE
UI: Subtract footer from main height

### DIFF
--- a/ui/src/styles/App.scss
+++ b/ui/src/styles/App.scss
@@ -10,7 +10,9 @@ body {
 }
 
 main {
-  min-height: 100%;
+  min-height: -webkit-calc(100% - 128px);
+  min-height:    -moz-calc(100% - 128px);
+  min-height:         calc(100% - 128px);
   overflow: auto;
   padding-top: 1rem;
 }


### PR DESCRIPTION
This is just a quick fix to bring the footer into the main view, given enough space.