### PR TITLE
UI: Fix Ghost Firefox rendering

### DIFF
--- a/ui/src/styles/Ghost.scss
+++ b/ui/src/styles/Ghost.scss
@@ -123,8 +123,8 @@ $scale: 2;
   display: block;
   position: absolute;
   top: (48px / $scale);
-  width: (4px / $scale);
-  height: (4px / $scale);
+  width: (4.4px / $scale);
+  height: (4.4px / $scale);
   z-index: 1;
 }
 


### PR DESCRIPTION
Something going on with the way firefox is doing subpixel rendering, and we are seeing small lines between some objects. Notably on our Ghost's feet. This PR slightly increases the dimensions of the foot to account for this issue. No visual changes on Chrome.